### PR TITLE
Make Transaction key not optional

### DIFF
--- a/Sources/Entities/PSTransaction.swift
+++ b/Sources/Entities/PSTransaction.swift
@@ -4,7 +4,7 @@ public class PSTransaction: Mappable {
     public var autoConfirm: Bool?
     public var useAllowance: Bool?
     public var payments: Array<PSPayment>?
-    public var key: String?
+    public var key: String!
     public var status: String?
     public var project: PSProject?
     public var redirectUri: String?


### PR DESCRIPTION
According to API (https://developers.paysera.com/en/wallet/payment/transaction) key is always guaranteed.